### PR TITLE
Allow custom vm name. Argument to display help message.

### DIFF
--- a/virt-manager-vm/serpentos.tmpl
+++ b/virt-manager-vm/serpentos.tmpl
@@ -1,5 +1,5 @@
 <domain type="kvm">
-    <name>serpentos</name>
+    <name>###SOSNAME###</name>
     <metadata>
       <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
         <libosinfo:os id="http://libosinfo.org/linux/2022"/>


### PR DESCRIPTION
Add a help argument so users can see options before creating a VM.

Also added the ability to change the VM name.  I did this because I had made a new VM with a different mount point thinking I could have two VMs but since the name was the same it overrode the original VM in virt-manager. Now a user could have two or more VMs going.