### PR TITLE
Add case insensitive flag to grep

### DIFF
--- a/virt-manager-vm/create-virtio-vm.sh
+++ b/virt-manager-vm/create-virtio-vm.sh
@@ -89,7 +89,7 @@ fi
 
 MSG="Setting up virt-mananger ${SOSNAME} instance from template..."
 printInfo "${MSG}"
-FOUNDPAYLOAD="$(find /usr/share -name OVMF_CODE.fd |grep ovmf/)"
+FOUNDPAYLOAD="$(find /usr/share -name OVMF_CODE.fd |grep -i ovmf/)"
 # Defaults to the location in Solus
 UEFIPAYLOAD="${FOUNDPAYLOAD:-/usr/share/edk2-ovmf/x64/OVMF_CODE.fd}"
 MSG="Found \$UEFIPAYLOAD: ${UEFIPAYLOAD}..."


### PR DESCRIPTION
This allows finding the correct OVMF_CODE.fd file on Debian based systems. For example: /usr/share/OVMF/OVMF_CODE.fd