### PR TITLE
desktop: Use tmpfs for ephemeral storage and compress w/lz4

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,0 +1,14 @@
+# Pre-alpha desktop image
+
+Requires 8GiB of free RAM because it uses tmpfs storage to create the various images comprising the ISO.
+
+## Troubleshooting
+
+> Ikey Doherty
+> but yeah in future for this sorta thing, edit `live-os.conf` to add `console=ttyS0` and remove the `quiet` param
+> then add `-serial stdio` to qemu
+> for BIOS we'd see the error
+> but qemu is a twat.
+> so the EFI mode initialisation doesn't happen properly and we dont see these errors
+> which is why we force getty1
+> (cuz first setup doesnt work properly)

--- a/desktop/img.sh
+++ b/desktop/img.sh
@@ -11,25 +11,12 @@ die () {
     exit 1
 }
 
+D="$(dirname $0)"
+echo "WORKDIR: ${D} "
+
 # Add escape codes for color
 RED='\033[0;31m'
 RESET='\033[0m'
-
-# Pkg list check
-test -f ./pkglist || die "\nThis script MUST be run from within the desktop/ dir with the ./pkglist file.\n"
-test -f ../pkglist-base || die "\nThis script MUST be able to find the ../pkglist-base file.\n"
-
-# start with a common base of packages
-readarray -t PACKAGES < ../pkglist-base
-
-# add linux-desktop specific packages
-PACKAGES+=($(cat ./pkglist))
-
-#echo -e "List of packages:\n${PACKAGES[@]}\n"
-#exit 1
-
-test -f ./initrdlist || die "initrd package list is absent"
-readarray -t initrd < initrdlist
 
 # Root check
 if [[ "${UID}" -ne 0 ]]; then
@@ -69,8 +56,21 @@ else
 fi
 #die "Exit because this is just a test."
 
-# From here on, exit from script on any non-zero exit status command result
-set -e
+# Pkg list check
+test -f ${D}/pkglist || die "\nThis script MUST be run from within the desktop/ dir with the ./pkglist file.\n"
+test -f ${D}/../pkglist-base || die "\nThis script MUST be able to find the ../pkglist-base file.\n"
+
+# start with a common base of packages
+readarray -t PACKAGES < ${D}/../pkglist-base
+
+# add linux-desktop specific packages
+PACKAGES+=($(cat ${D}/pkglist))
+
+#echo -e "List of packages:\n${PACKAGES[@]}\n"
+#exit 1
+
+test -f ${D}/initrdlist || die "initrd package list is absent"
+readarray -t initrd < ${D}/initrdlist
 
 DIRS=(
     mount
@@ -82,111 +82,129 @@ DIRS=(
     overlay.work
 )
 
-# clean up dirs
-for d in ${DIRS[@]}; do
-    test -d ${d} && rm -rf ${d}
-done
-# clean up existing rootfs.img
-test -e rootfs.img && rm -f rootfs.img
+cleanup () {
+    echo -e "\nCleaning up existing dirs, files and mount points...\n"
+    # clean up dirs
+    for d in ${DIRS[@]}; do
+        test -d ${D}/${d} && rm -rf ${D}/${d}
+    done
+
+    # umount existing mount recursively and lazily
+    test -d ${D}/mount && umount -Rlv ${D}/mount
+
+    # clean up existing rootfs.img
+    test -e ${D}/rootfs.img && rm -f ${D}/rootfs.img
+}
+cleanup
+
+die-and-cleanup() {
+    cleanup
+    die $*
+}
+
+# From here on, exit from script on any non-zero exit status command result
+set -e
 
 # Stash boot assets
-mkdir -pv boot
+mkdir -pv ${D}/boot
 
 # Get it right first time.
-mkdir -pv mount
-chown -Rc root:root mount
-chmod -Rc 00755 mount
+mkdir -pv ${D}/mount
+chown -Rc root:root ${D}/mount
+chmod -Rc 00755 ${D}/mount
 
 # Setup the root image
-fallocate -l 10GB rootfs.img
+fallocate -l 10GB ${D}/rootfs.img
 # don't want/need journaling on the fs
-mkfs.ext3 -F rootfs.img
-mount -o loop rootfs.img mount
+mkfs.ext3 -F ${D}/rootfs.img
+mount -o loop ${D}/rootfs.img ${D}/mount
+
+export RUST_BACKTRACE=1
 
 # Add repositories
-moss -D mount/ repo add volatile https://dev.serpentos.com/volatile/x86_64/stone.index
+moss -D ${D}/mount/ repo add volatile https://dev.serpentos.com/volatile/x86_64/stone.index || die-and-cleanup "Adding moss repo failed!"
 
 # Install the PACKAGES
-moss -D mount/ install -y "${PACKAGES[@]}"
+moss -D ${D}/mount/ install -y "${PACKAGES[@]}" || die-and-cleanup "Installing packages failed!"
 
 # Fix ldconfig
-mkdir -pv mount/var/cache/ldconfig
-moss-container -u 0 -d mount/ -- ldconfig
+mkdir -pv ${D}/mount/var/cache/ldconfig
+moss-container -u 0 -d ${D}/mount/ -- ldconfig
 
 # Get basic env working
-moss-container -u 0 -d mount/ -- systemd-sysusers
-moss-container -u 0 -d mount/ -- systemd-tmpfiles --create
-moss-container -u 0 -d mount/ -- systemd-firstboot --force --setup-machine-id --delete-root-password --locale=en_US.UTF-8 --timezone=UTC --root-shell=/usr/bin/bash
-moss-container -u 0 -d mount/ -- systemctl enable systemd-resolved systemd-networkd getty@tty1
+moss-container -u 0 -d ${D}/mount/ -- systemd-sysusers
+moss-container -u 0 -d ${D}/mount/ -- systemd-tmpfiles --create
+moss-container -u 0 -d ${D}/mount/ -- systemd-firstboot --force --setup-machine-id --delete-root-password --locale=en_US.UTF-8 --timezone=UTC --root-shell=/usr/bin/bash
+moss-container -u 0 -d ${D}/mount/ -- systemctl enable systemd-resolved systemd-networkd getty@tty1
 
 # Fix perf issues. Needs packaging/merging by moss
-moss-container -u 0 -d mount/ -- systemd-hwdb update
+moss-container -u 0 -d ${D}/mount/ -- systemd-hwdb update
 
 # Extract assets
-cp -v mount/usr/lib/systemd/boot/efi/systemd-bootx64.efi boot/bootx64.efi
-cp -v mount/usr/lib/kernel/com.serpentos.* boot/kernel
+cp -v ${D}/mount/usr/lib/systemd/boot/efi/systemd-bootx64.efi ${D}/boot/bootx64.efi
+cp -v ${D}/mount/usr/lib/kernel/com.serpentos.* ${D}/boot/kernel
 
 # Setup the overlay.
-mkdir overlay.upper
-mkdir overlay.mount
-mkdir overlay.work
+mkdir ${D}/overlay.upper
+mkdir ${D}/overlay.mount
+mkdir ${D}/overlay.work
 
-mount -t overlay -o lowerdir=$(pwd)/mount,upperdir=$(pwd)/overlay.upper,workdir=$(pwd)/overlay.work,redirect_dir=on overlay overlay.mount || die "Failed to mount overlay"
+mount -t overlay -o lowerdir=${D}/mount,upperdir=${D}/overlay.upper,workdir=${D}/overlay.work,redirect_dir=on overlay ${D}/overlay.mount || die "Failed to mount overlay"
 
 # Install dracut now
-moss -D overlay.mount install "${initrd[@]}" -y || die "Failed to install overlay packages"
+moss -D ${D}/overlay.mount install "${initrd[@]}" -y || die "Failed to install overlay packages"
 
 # Regenerate dracut. BLUH.
-kver=$(ls mount/usr/lib/modules)
-moss-container -u 0 -d overlay.mount/ -- dracut --early-microcode --hardlink -N --nomdadmconf --nolvmconf --kver ${kver} --add "bash dash systemd lvm dm dmsquash-live" --fwdir /usr/lib/firmware --tmpdir /tmp --zstd --strip /initrd
-cp -v overlay.mount/initrd boot/initrd
+kver=$(ls ${D}/mount/usr/lib/modules)
+moss-container -u 0 -d ${D}/overlay.mount/ -- dracut --early-microcode --hardlink -N --nomdadmconf --nolvmconf --kver ${kver} --add "bash dash systemd lvm dm dmsquash-live" --fwdir /usr/lib/firmware --tmpdir /tmp --zstd --strip /initrd
+cp -v ${D}/overlay.mount/initrd ${D}/boot/initrd
 
 # Tear it down
-umount $(pwd)/overlay.mount
+umount ${D}/overlay.mount
 
 # Cleanup!
-rm -rf mount/.moss/cache/downloads/*
-umount $(pwd)/mount
+rm -rf ${D}/mount/.moss/cache/downloads/*
+umount ${D}/mount
 
 # Shrink size to minimum
-resize2fs -M rootfs.img -f
+resize2fs -M ${D}/rootfs.img -f
 
 # Force a check on it
-e2fsck -fy rootfs.img
+e2fsck -fy ${D}/rootfs.img
 
 # Now gen the structure
 
-mkdir -pv LiveOS
-mv -v rootfs.img LiveOS/.
-mksquashfs LiveOS/ squashfs.img -comp zstd -root-becomes LiveOS -keep-as-directory -all-root
-rm -f LiveOS/rootfs.img
-mv -v squashfs.img LiveOS/.
+mkdir -pv ${D}/LiveOS
+mv -v ${D}/rootfs.img ${D}/LiveOS/.
+mksquashfs ${D}/LiveOS/ ${D}/squashfs.img -comp zstd -root-becomes LiveOS -keep-as-directory -all-root
+rm -f ${D}/LiveOS/rootfs.img
+mv -v ${D}/squashfs.img ${D}/LiveOS/.
 
-mkdir -pv root
-mv -v LiveOS root/.
+mkdir -pv ${D}/root
+mv -v ${D}/LiveOS ${D}/root/.
 
 # Create the efi img
-fallocate -l 45M efi.img
-mkfs.vfat -F 12 efi.img -n EFIBOOTISO
-mount -o loop efi.img mount
+fallocate -l 45M ${D}/efi.img
+mkfs.vfat -F 12 ${D}/efi.img -n EFIBOOTISO
+mount -o loop ${D}/efi.img ${D}/mount
 
 # Set it up...
-mkdir -pv mount/EFI/Boot
-cp -v boot/bootx64.efi mount/EFI/Boot/bootx64.efi
+mkdir -pv ${D}/mount/EFI/Boot
+cp -v ${D}/boot/bootx64.efi ${D}/mount/EFI/Boot/bootx64.efi
 sync
-mkdir -pv mount/loader/entries
-cp -v live-os.conf mount/loader/entries/.
-cp -v boot/kernel mount/kernel
-cp -v boot/initrd mount/initrd
-umount $(pwd)/mount
+mkdir -pv ${D}/mount/loader/entries
+cp -v ${D}/live-os.conf ${D}/mount/loader/entries/.
+cp -v ${D}/boot/kernel ${D}/mount/kernel
+cp -v ${D}/boot/initrd ${D}/mount/initrd
+umount ${D}/mount
 
 # Put it in place
-mkdir -pv root/EFI/Boot
-mv -v efi.img root/EFI/Boot/efiboot.img
+mkdir -pv ${D}/root/EFI/Boot
+mv -v ${D}/efi.img ${D}/root/EFI/Boot/efiboot.img
 
 # Create the ISO
 xorriso -as mkisofs \
-    -o snekvalidator.iso \
+    -o ${D}/snekvalidator.iso \
     -R -J -v -d -N \
     -x snekvalidator.iso \
     -hide-rr-moved \
@@ -197,4 +215,5 @@ xorriso -as mkisofs \
     -V "SERPENTISO" -A "SERPENTISO" \
     root
 
-# TODO: Generate an ISO
+unset RUST_BACKTRACE=1
+unset D

--- a/desktop/img.sh
+++ b/desktop/img.sh
@@ -11,10 +11,10 @@ die () {
     exit 1
 }
 
-W="$(dirname $0)"
-echo ">>> workdir \${W}: ${W}"
-T="/tmp/serpent-image"
-echo ">>> tmpfs dir \${T}: ${T}"
+WORK="$(dirname $(realpath $0))"
+echo ">>> workdir \${WORK}: ${WORK}"
+TMPFS="/tmp/serpent_iso"
+echo ">>> tmpfs dir \${TMPFS}: ${TMPFS}"
 
 # Add escape codes for color
 RED='\033[0;31m'
@@ -62,20 +62,20 @@ fi
 #die "Exit because this is just a test."
 
 # Pkg list check
-test -f ${W}/pkglist || die "\nThis script MUST be run from within the desktop/ dir with the ./pkglist file.\n"
-test -f ${W}/../pkglist-base || die "\nThis script MUST be able to find the ../pkglist-base file.\n"
+test -f ${WORK}/pkglist || die "\nThis script MUST be run from within the desktop/ dir with the ./pkglist file.\n"
+test -f ${WORK}/../pkglist-base || die "\nThis script MUST be able to find the ../pkglist-base file.\n"
 
 # start with a common base of packages
-readarray -t PACKAGES < ${W}/../pkglist-base
+readarray -t PACKAGES < ${WORK}/../pkglist-base
 
 # add linux-desktop specific packages
-PACKAGES+=($(cat ${W}/pkglist))
+PACKAGES+=($(cat ${WORK}/pkglist))
 
 #echo -e "List of packages:\n${PACKAGES[@]}\n"
 #exit 1
 
-test -f ${W}/initrdlist || die "initrd package list is absent"
-readarray -t initrd < ${W}/initrdlist
+test -f ${WORK}/initrdlist || die "initrd package list is absent"
+readarray -t initrd < ${WORK}/initrdlist
 
 DIRS=(
     LiveOS
@@ -88,13 +88,13 @@ DIRS=(
 cleanup () {
     echo -e "\nCleaning up existing dirs, files and mount points...\n"
     # clean up dirs
-    rm -rf ${T}/*
+    rm -rf ${TMPFS}/*
 
-        # umount existing mount recursively and lazily
-    test -d ${T}/mount && umount -Rlv ${T}/mount
+    # umount existing mount recursively and lazily
+    test -d ${TMPFS}/mount && umount -Rlv ${TMPFS}/mount
 
     # clean up existing rootfs.img
-    test -e ${T}/rootfs.img && rm -f ${T}/rootfs.img
+    test -e ${TMPFS}/rootfs.img && rm -f ${TMPFS}/rootfs.img
 }
 cleanup
 
@@ -106,132 +106,115 @@ die-and-cleanup() {
 # From here on, exit from script on any non-zero exit status command result
 set -e
 
-export B="${T}/boot"
-export M="${T}/mount"
-export SFS="${T}/serpentfs"
+export BOOT="${TMPFS}/boot"
+export MOUNT="${TMPFS}/mount"
+export SFSDIR="${TMPFS}/serpentfs"
 
 # Stash boot assets
-mkdir -pv ${B}
+mkdir -pv ${BOOT}
 
 # Get it right first time.
-mkdir -pv ${M} ${SFS}
-chown -Rc root:root ${M} ${SFS}
+mkdir -pv ${MOUNT} ${SFSDIR}
+chown -Rc root:root ${MOUNT} ${SFSDIR}
 # Only chmod directories
-chmod -Rc u=rwX,g=rX,o=rX ${M} ${SFS}
+chmod -Rc u=rwX,g=rX,o=rX ${MOUNT} ${SFSDIR}
 
 export RUST_BACKTRACE=1
 
-echo ">>> Add moss volatile repository to ${SFS}/..."
-time moss -D ${SFS} repo add volatile https://dev.serpentos.com/volatile/x86_64/stone.index || die-and-cleanup "Adding moss repo failed!"
+echo ">>> Add moss volatile repository to ${SFSDIR}/ ..."
+time moss -D ${SFSDIR} repo add volatile https://dev.serpentos.com/volatile/x86_64/stone.index || die-and-cleanup "Adding moss repo failed!"
 
-echo ">>> Install packages to ${SFS}/..."
-time moss -D ${SFS} install -y "${PACKAGES[@]}" || die-and-cleanup "Installing packages failed!"
+echo ">>> Install packages to ${SFSDIR}/ ..."
+time moss -D ${SFSDIR} install -y "${PACKAGES[@]}" || die-and-cleanup "Installing packages failed!"
 
-echo ">>> Fix ldconfig in ${SFS}/..."
-mkdir -pv ${SFS}/var/cache/ldconfig
-time moss-container -u 0 -d ${SFS} -- ldconfig
+echo ">>> Fix ldconfig in ${SFSDIR}/ ..."
+mkdir -pv ${SFSDIR}/var/cache/ldconfig
+time moss-container -u 0 -d ${SFSDIR} -- ldconfig
 
-echo ">>> Set up basic environment in ${SFS}..."
-time moss-container -u 0 -d ${SFS} -- systemd-sysusers
-time moss-container -u 0 -d ${SFS} -- systemd-tmpfiles --create
-time moss-container -u 0 -d ${SFS} -- systemd-firstboot --force --setup-machine-id --delete-root-password --locale=en_US.UTF-8 --timezone=UTC --root-shell=/usr/bin/bash
-time moss-container -u 0 -d ${SFS} -- systemctl enable systemd-resolved systemd-networkd getty@tty1
+echo ">>> Set up basic environment in ${SFSDIR}/ ..."
+time moss-container -u 0 -d ${SFSDIR} -- systemd-sysusers
+time moss-container -u 0 -d ${SFSDIR} -- systemd-tmpfiles --create
+time moss-container -u 0 -d ${SFSDIR} -- systemd-firstboot --force --setup-machine-id --delete-root-password --locale=en_US.UTF-8 --timezone=UTC --root-shell=/usr/bin/bash
+time moss-container -u 0 -d ${SFSDIR} -- systemctl enable systemd-resolved systemd-networkd getty@tty1
 
 echo ">>> Fix performance issues. Needs packaging/merging by moss"
-time moss-container -u 0 -d ${SFS} -- systemd-hwdb update
+time moss-container -u 0 -d ${SFSDIR} -- systemd-hwdb update
 
 echo ">>> Extract assets..."
-cp -av ${SFS}/usr/lib/systemd/boot/efi/systemd-bootx64.efi ${B}/bootx64.efi
-cp -av ${SFS}/usr/lib/kernel/com.serpentos.* ${B}/kernel
+cp -av ${SFSDIR}/usr/lib/systemd/boot/efi/systemd-bootx64.efi ${BOOT}/bootx64.efi
+cp -av ${SFSDIR}/usr/lib/kernel/com.serpentos.* ${BOOT}/kernel
 
-#echo ">>> Set up overlayFS mounts..."
-#rm -rf ${W}/overlay.*
-#mkdir -pv ${W}/overlay.upper
-#mkdir -pv ${W}/overlay.mount
-#mkdir -pv ${W}/overlay.work
-
-#mount -v -t overlay -o lowerdir=${M},upperdir=${W}/overlay.upper,workdir=${W}/overlay.work,redirect_dir=on overlay ${W}/overlay.mount || die-and-cleanup "Failed to mount overlay"
-
-#echo ">>> Add moss volatile repository to ${W}/overlay.mount/ ..."
-#time moss -D ${W}/overlay.mount repo add volatile https://dev.serpentos.com/volatile/x86_64/stone.index || die-and-cleanup "Adding moss repo failed!"
-
-echo ">>> Install dracut in ${SFS}/ ..."
-time moss -D ${SFS} install "${initrd[@]}" -y || die-and-cleanup "Failed to install initrd packages!"
+echo ">>> Install dracut in ${SFSDIR}/ ..."
+time moss -D ${SFSDIR} install "${initrd[@]}" -y || die-and-cleanup "Failed to install initrd packages!"
 
 echo ">>> Regenerate dracut..."
-kver=$(ls ${SFS}/usr/lib/modules)
-time moss-container -u 0 -d ${SFS}/ -- dracut --early-microcode --hardlink -N --nomdadmconf --nolvmconf --kver ${kver} --add "bash dash systemd lvm dm dmsquash-live" --fwdir /usr/lib/firmware --tmpdir /tmp --zstd --strip /initrd
-mv -v ${SFS}/initrd ${B}/initrd
+kver=$(ls ${SFSDIR}/usr/lib/modules)
+time moss-container -u 0 -d ${SFSDIR}/ -- dracut --early-microcode --hardlink -N --nomdadmconf --nolvmconf --kver ${kver} --add "bash dash systemd lvm dm dmsquash-live" --fwdir /usr/lib/firmware --tmpdir /tmp --zstd --strip /initrd
+mv -v ${SFSDIR}/initrd ${BOOT}/initrd
 
-#echo ">>> Tear down overlayFS mount..."
-#umount -Rlv ${W}/overlay.mount
-
-echo ">>> Clean up ${SFS}/ ..."
-time moss -D ${SFS} remove "${initrd[@]}" -y || die-and-cleanup "Failed to remove initrd packages from ${T}/ !"
-time moss -D ${SFS} install -y "${PACKAGES[@]}" || die-and-cleanup "Installing packages failed!"
+echo ">>> Clean up ${SFSDIR}/ ..."
+time moss -D ${SFSDIR} remove "${initrd[@]}" -y || die-and-cleanup "Failed to remove initrd packages from ${TMPFS}/ !"
+time moss -D ${SFSDIR} install -y "${PACKAGES[@]}" || die-and-cleanup "Installing packages failed!"
 
 # Keep only latest state (= currently installed)
-time moss -D ${SFS} state prune -k1 -y || die-and-cleanup "Failed to prune moss state in ${T}/ !"
+time moss -D ${SFSDIR} state prune -k1 -y || die-and-cleanup "Failed to prune moss state in ${TMPFS}/ !"
 # Remove downloaded .stones
-rm -rf ${SFS}/.moss/cache/downloads/*
+rm -rf ${SFSDIR}/.moss/cache/downloads/*
 
-
-# transfer prepared new rootfs to rootfs.img
-#cp -avx ${T}/* ${T}/.moss ${M}/ # <- segfaults for me on Solus
-echo ">>> Transfer ${SFS}/ contents to rootfs.img mounted on ${M}/ ..."
-IMGSIZE=$(du -BMiB -s ${T}|cut -f1|sed -e 's|MiB||g')
+#cp -avx ${TMPFS}/* ${TMPFS}/.moss ${MOUNT}/ # <- segfaults for me on Solus
+echo ">>> Transfer ${SFSDIR}/ contents to rootfs.img mounted on ${MOUNT}/ ..."
+IMGSIZE=$(du -BMiB -s ${TMPFS}|cut -f1|sed -e 's|MiB||g')
 echo ">>> IMAGSIZE=${IMGSIZE}"
-# Setup the root image to be twice as large as the SFS folder total size in MiB
-fallocate -l $((${IMGSIZE} * 2))MiB ${T}/rootfs.img
+# Set up the root image to be twice as large as the SFS folder total size in MiB
+fallocate -l $((${IMGSIZE} * 2))MiB ${TMPFS}/rootfs.img
 # don't want/need journaling on the fs
-mkfs.ext3 -F ${T}/rootfs.img
-mount -vo loop ${T}/rootfs.img ${M}
+mkfs.ext3 -F ${TMPFS}/rootfs.img
+mount -vo loop ${TMPFS}/rootfs.img ${MOUNT}
 
-time tar -C ${SFS} -cf - ./  | tar -C ${M} --totals --checkpoint=20000 -xpf -
+time tar -C ${SFSDIR} -cf - ./  | tar -C ${MOUNT} --totals --checkpoint=20000 -xpf -
 # save memory once the FS has been created
-rm -rf ${SFS}
-umount -Rlv ${M}/
+rm -rf ${SFSDIR}
+umount -Rlv ${MOUNT}/
 
-#echo ">>> Shrink rootfs.img size to minimum..."
-resize2fs -Mfp ${T}/rootfs.img
+echo ">>> Shrink rootfs.img size to minimum..."
+resize2fs -Mfp ${TMPFS}/rootfs.img
 
 echo ">>> Force a filesystem check on rootfs.img..."
-e2fsck -fvy ${T}/rootfs.img
+e2fsck -fvy ${TMPFS}/rootfs.img
 
 echo ">>> Generate the LiveOS image structure..."
+mkdir -pv ${TMPFS}/LiveOS
+ln -v ${TMPFS}/rootfs.img ${TMPFS}/LiveOS/
+#time mksquashfs ${WORK}/LiveOS/ ${WORK}/squashfs.img -root-becomes LiveOS -keep-as-directory -all-root -b 1M -info -progress -comp zstd
+time mksquashfs ${TMPFS}/LiveOS/ ${TMPFS}/squashfs.img -root-becomes LiveOS -keep-as-directory -all-root -b 1M -info -progress -comp lz4 #-Xhc
+rm -f ${TMPFS}/LiveOS/rootfs.img
+ln -v ${TMPFS}/squashfs.img ${TMPFS}/LiveOS/
 
-mkdir -pv ${T}/LiveOS
-ln -v ${T}/rootfs.img ${T}/LiveOS/
-#mksquashfs ${W}/LiveOS/ ${W}/squashfs.img -comp zstd -root-becomes LiveOS -keep-as-directory -all-root
-time mksquashfs ${T}/LiveOS/ ${T}/squashfs.img -root-becomes LiveOS -keep-as-directory -all-root -b 1M -info -progress -comp lz4 #-Xhc
-rm -f ${T}/LiveOS/rootfs.img
-ln -v ${T}/squashfs.img ${T}/LiveOS/
-
-mkdir -pv ${T}/root
-mv -v ${T}/LiveOS ${T}/root/.
+mkdir -pv ${TMPFS}/root
+mv -v ${TMPFS}/LiveOS ${TMPFS}/root/.
 
 echo ">>> Create and mount the efi.mg backing file..."
-fallocate -l 45M ${T}/efi.img
-mkfs.vfat -F 12 ${T}/efi.img -n EFIBOOTISO
-mount -vo loop ${T}/efi.img ${M}
+fallocate -l 45M ${TMPFS}/efi.img
+mkfs.vfat -F 12 ${TMPFS}/efi.img -n EFIBOOTISO
+mount -vo loop ${TMPFS}/efi.img ${MOUNT}
 
 echo ">>> Set up EFI image..."
-mkdir -pv ${T}/mount/EFI/Boot
-cp -v ${B}/bootx64.efi ${M}/EFI/Boot/bootx64.efi
+mkdir -pv ${TMPFS}/mount/EFI/Boot
+cp -v ${BOOT}/bootx64.efi ${MOUNT}/EFI/Boot/bootx64.efi
 sync
-mkdir -pv ${T}/mount/loader/entries
-cp -v ${W}/live-os.conf ${M}/loader/entries/.
-cp -v ${B}/kernel ${M}/kernel
-cp -v ${B}/initrd ${M}/initrd
-umount -Rlv ${M}
+mkdir -pv ${TMPFS}/mount/loader/entries
+cp -v ${WORK}/live-os.conf ${MOUNT}/loader/entries/.
+cp -v ${BOOT}/kernel ${MOUNT}/kernel
+cp -v ${BOOT}/initrd ${MOUNT}/initrd
+umount -Rlv ${MOUNT}
 
 echo ">>> Put the new EFI image in the correct place..."
-mkdir -pv ${T}/root/EFI/Boot
-mv -v ${T}/efi.img ${T}/root/EFI/Boot/efiboot.img
+mkdir -pv ${TMPFS}/root/EFI/Boot
+mv -v ${TMPFS}/efi.img ${TMPFS}/root/EFI/Boot/efiboot.img
 
 echo ">>> Create the ISO file..."
 xorriso -as mkisofs \
-    -o ${W}/snekvalidator.iso \
+    -o ${WORK}/snekvalidator.iso \
     -R -J -v -d -N \
     -x snekvalidator.iso \
     -hide-rr-moved \
@@ -240,13 +223,13 @@ xorriso -as mkisofs \
     -eltorito-boot EFI/Boot/efiboot.img \
     -isohybrid-gpt-basdat \
     -V "SERPENTISO" -A "SERPENTISO" \
-    ${T}/root
+    ${TMPFS}/root
 
 cleanup
 
 unset RUST_BACKTRACE=1
-unset B
-unset F
-unset M
-unset T
-unset W
+unset BOOT
+unset SFSDIR
+unset MOUNT
+unset TMPFS
+unset WORK

--- a/desktop/img.sh
+++ b/desktop/img.sh
@@ -11,8 +11,10 @@ die () {
     exit 1
 }
 
-D="$(dirname $0)"
-echo "WORKDIR: ${D} "
+W="$(dirname $0)"
+echo ">>> workdir \${W}: ${W}"
+T="/tmp/serpent-image"
+echo ">>> tmpfs dir \${T}: ${T}"
 
 # Add escape codes for color
 RED='\033[0;31m'
@@ -26,14 +28,17 @@ fi
 BINARIES=(
     e2fsck
     fallocate
+    lz4
     mkfs.ext3
     mkfs.vfat
+    mksquashfs
     moss
     moss-container
     mount
     resize2fs
     sync
     xorriso
+    zstd
 )
 # up front check for necessary binaries
 BINARY_NOT_FOUND=0
@@ -57,43 +62,39 @@ fi
 #die "Exit because this is just a test."
 
 # Pkg list check
-test -f ${D}/pkglist || die "\nThis script MUST be run from within the desktop/ dir with the ./pkglist file.\n"
-test -f ${D}/../pkglist-base || die "\nThis script MUST be able to find the ../pkglist-base file.\n"
+test -f ${W}/pkglist || die "\nThis script MUST be run from within the desktop/ dir with the ./pkglist file.\n"
+test -f ${W}/../pkglist-base || die "\nThis script MUST be able to find the ../pkglist-base file.\n"
 
 # start with a common base of packages
-readarray -t PACKAGES < ${D}/../pkglist-base
+readarray -t PACKAGES < ${W}/../pkglist-base
 
 # add linux-desktop specific packages
-PACKAGES+=($(cat ${D}/pkglist))
+PACKAGES+=($(cat ${W}/pkglist))
 
 #echo -e "List of packages:\n${PACKAGES[@]}\n"
 #exit 1
 
-test -f ${D}/initrdlist || die "initrd package list is absent"
-readarray -t initrd < ${D}/initrdlist
+test -f ${W}/initrdlist || die "initrd package list is absent"
+readarray -t initrd < ${W}/initrdlist
 
 DIRS=(
-    mount
-    root
     LiveOS
     boot
-    overlay.upper
-    overlay.mount
-    overlay.work
+    mount
+    root
+    serpentfs
 )
 
 cleanup () {
     echo -e "\nCleaning up existing dirs, files and mount points...\n"
     # clean up dirs
-    for d in ${DIRS[@]}; do
-        test -d ${D}/${d} && rm -rf ${D}/${d}
-    done
+    rm -rf ${T}/*
 
-    # umount existing mount recursively and lazily
-    test -d ${D}/mount && umount -Rlv ${D}/mount
+        # umount existing mount recursively and lazily
+    test -d ${T}/mount && umount -Rlv ${T}/mount
 
     # clean up existing rootfs.img
-    test -e ${D}/rootfs.img && rm -f ${D}/rootfs.img
+    test -e ${T}/rootfs.img && rm -f ${T}/rootfs.img
 }
 cleanup
 
@@ -105,106 +106,132 @@ die-and-cleanup() {
 # From here on, exit from script on any non-zero exit status command result
 set -e
 
+export B="${T}/boot"
+export M="${T}/mount"
+export SFS="${T}/serpentfs"
+
 # Stash boot assets
-mkdir -pv ${D}/boot
+mkdir -pv ${B}
 
 # Get it right first time.
-mkdir -pv ${D}/mount
-chown -Rc root:root ${D}/mount
-chmod -Rc 00755 ${D}/mount
-
-# Setup the root image
-fallocate -l 10GB ${D}/rootfs.img
-# don't want/need journaling on the fs
-mkfs.ext3 -F ${D}/rootfs.img
-mount -o loop ${D}/rootfs.img ${D}/mount
+mkdir -pv ${M} ${SFS}
+chown -Rc root:root ${M} ${SFS}
+# Only chmod directories
+chmod -Rc u=rwX,g=rX,o=rX ${M} ${SFS}
 
 export RUST_BACKTRACE=1
 
-# Add repositories
-moss -D ${D}/mount/ repo add volatile https://dev.serpentos.com/volatile/x86_64/stone.index || die-and-cleanup "Adding moss repo failed!"
+echo ">>> Add moss volatile repository to ${SFS}/..."
+time moss -D ${SFS} repo add volatile https://dev.serpentos.com/volatile/x86_64/stone.index || die-and-cleanup "Adding moss repo failed!"
 
-# Install the PACKAGES
-moss -D ${D}/mount/ install -y "${PACKAGES[@]}" || die-and-cleanup "Installing packages failed!"
+echo ">>> Install packages to ${SFS}/..."
+time moss -D ${SFS} install -y "${PACKAGES[@]}" || die-and-cleanup "Installing packages failed!"
 
-# Fix ldconfig
-mkdir -pv ${D}/mount/var/cache/ldconfig
-moss-container -u 0 -d ${D}/mount/ -- ldconfig
+echo ">>> Fix ldconfig in ${SFS}/..."
+mkdir -pv ${SFS}/var/cache/ldconfig
+time moss-container -u 0 -d ${SFS} -- ldconfig
 
-# Get basic env working
-moss-container -u 0 -d ${D}/mount/ -- systemd-sysusers
-moss-container -u 0 -d ${D}/mount/ -- systemd-tmpfiles --create
-moss-container -u 0 -d ${D}/mount/ -- systemd-firstboot --force --setup-machine-id --delete-root-password --locale=en_US.UTF-8 --timezone=UTC --root-shell=/usr/bin/bash
-moss-container -u 0 -d ${D}/mount/ -- systemctl enable systemd-resolved systemd-networkd getty@tty1
+echo ">>> Set up basic environment in ${SFS}..."
+time moss-container -u 0 -d ${SFS} -- systemd-sysusers
+time moss-container -u 0 -d ${SFS} -- systemd-tmpfiles --create
+time moss-container -u 0 -d ${SFS} -- systemd-firstboot --force --setup-machine-id --delete-root-password --locale=en_US.UTF-8 --timezone=UTC --root-shell=/usr/bin/bash
+time moss-container -u 0 -d ${SFS} -- systemctl enable systemd-resolved systemd-networkd getty@tty1
 
-# Fix perf issues. Needs packaging/merging by moss
-moss-container -u 0 -d ${D}/mount/ -- systemd-hwdb update
+echo ">>> Fix performance issues. Needs packaging/merging by moss"
+time moss-container -u 0 -d ${SFS} -- systemd-hwdb update
 
-# Extract assets
-cp -v ${D}/mount/usr/lib/systemd/boot/efi/systemd-bootx64.efi ${D}/boot/bootx64.efi
-cp -v ${D}/mount/usr/lib/kernel/com.serpentos.* ${D}/boot/kernel
+echo ">>> Extract assets..."
+cp -av ${SFS}/usr/lib/systemd/boot/efi/systemd-bootx64.efi ${B}/bootx64.efi
+cp -av ${SFS}/usr/lib/kernel/com.serpentos.* ${B}/kernel
 
-# Setup the overlay.
-mkdir ${D}/overlay.upper
-mkdir ${D}/overlay.mount
-mkdir ${D}/overlay.work
+#echo ">>> Set up overlayFS mounts..."
+#rm -rf ${W}/overlay.*
+#mkdir -pv ${W}/overlay.upper
+#mkdir -pv ${W}/overlay.mount
+#mkdir -pv ${W}/overlay.work
 
-mount -t overlay -o lowerdir=${D}/mount,upperdir=${D}/overlay.upper,workdir=${D}/overlay.work,redirect_dir=on overlay ${D}/overlay.mount || die "Failed to mount overlay"
+#mount -v -t overlay -o lowerdir=${M},upperdir=${W}/overlay.upper,workdir=${W}/overlay.work,redirect_dir=on overlay ${W}/overlay.mount || die-and-cleanup "Failed to mount overlay"
 
-# Install dracut now
-moss -D ${D}/overlay.mount install "${initrd[@]}" -y || die "Failed to install overlay packages"
+#echo ">>> Add moss volatile repository to ${W}/overlay.mount/ ..."
+#time moss -D ${W}/overlay.mount repo add volatile https://dev.serpentos.com/volatile/x86_64/stone.index || die-and-cleanup "Adding moss repo failed!"
 
-# Regenerate dracut. BLUH.
-kver=$(ls ${D}/mount/usr/lib/modules)
-moss-container -u 0 -d ${D}/overlay.mount/ -- dracut --early-microcode --hardlink -N --nomdadmconf --nolvmconf --kver ${kver} --add "bash dash systemd lvm dm dmsquash-live" --fwdir /usr/lib/firmware --tmpdir /tmp --zstd --strip /initrd
-cp -v ${D}/overlay.mount/initrd ${D}/boot/initrd
+echo ">>> Install dracut in ${SFS}/ ..."
+time moss -D ${SFS} install "${initrd[@]}" -y || die-and-cleanup "Failed to install initrd packages!"
 
-# Tear it down
-umount ${D}/overlay.mount
+echo ">>> Regenerate dracut..."
+kver=$(ls ${SFS}/usr/lib/modules)
+time moss-container -u 0 -d ${SFS}/ -- dracut --early-microcode --hardlink -N --nomdadmconf --nolvmconf --kver ${kver} --add "bash dash systemd lvm dm dmsquash-live" --fwdir /usr/lib/firmware --tmpdir /tmp --zstd --strip /initrd
+mv -v ${SFS}/initrd ${B}/initrd
 
-# Cleanup!
-rm -rf ${D}/mount/.moss/cache/downloads/*
-umount ${D}/mount
+#echo ">>> Tear down overlayFS mount..."
+#umount -Rlv ${W}/overlay.mount
 
-# Shrink size to minimum
-resize2fs -M ${D}/rootfs.img -f
+echo ">>> Clean up ${SFS}/ ..."
+time moss -D ${SFS} remove "${initrd[@]}" -y || die-and-cleanup "Failed to remove initrd packages from ${T}/ !"
+time moss -D ${SFS} install -y "${PACKAGES[@]}" || die-and-cleanup "Installing packages failed!"
 
-# Force a check on it
-e2fsck -fy ${D}/rootfs.img
+# Keep only latest state (= currently installed)
+time moss -D ${SFS} state prune -k1 -y || die-and-cleanup "Failed to prune moss state in ${T}/ !"
+# Remove downloaded .stones
+rm -rf ${SFS}/.moss/cache/downloads/*
 
-# Now gen the structure
 
-mkdir -pv ${D}/LiveOS
-mv -v ${D}/rootfs.img ${D}/LiveOS/.
-mksquashfs ${D}/LiveOS/ ${D}/squashfs.img -comp zstd -root-becomes LiveOS -keep-as-directory -all-root
-rm -f ${D}/LiveOS/rootfs.img
-mv -v ${D}/squashfs.img ${D}/LiveOS/.
+# transfer prepared new rootfs to rootfs.img
+#cp -avx ${T}/* ${T}/.moss ${M}/ # <- segfaults for me on Solus
+echo ">>> Transfer ${SFS}/ contents to rootfs.img mounted on ${M}/ ..."
+IMGSIZE=$(du -BMiB -s ${T}|cut -f1|sed -e 's|MiB||g')
+echo ">>> IMAGSIZE=${IMGSIZE}"
+# Setup the root image to be twice as large as the SFS folder total size in MiB
+fallocate -l $((${IMGSIZE} * 2))MiB ${T}/rootfs.img
+# don't want/need journaling on the fs
+mkfs.ext3 -F ${T}/rootfs.img
+mount -vo loop ${T}/rootfs.img ${M}
 
-mkdir -pv ${D}/root
-mv -v ${D}/LiveOS ${D}/root/.
+time tar -C ${SFS} -cf - ./  | tar -C ${M} --totals --checkpoint=20000 -xpf -
+# save memory once the FS has been created
+rm -rf ${SFS}
+umount -Rlv ${M}/
 
-# Create the efi img
-fallocate -l 45M ${D}/efi.img
-mkfs.vfat -F 12 ${D}/efi.img -n EFIBOOTISO
-mount -o loop ${D}/efi.img ${D}/mount
+#echo ">>> Shrink rootfs.img size to minimum..."
+resize2fs -Mfp ${T}/rootfs.img
 
-# Set it up...
-mkdir -pv ${D}/mount/EFI/Boot
-cp -v ${D}/boot/bootx64.efi ${D}/mount/EFI/Boot/bootx64.efi
+echo ">>> Force a filesystem check on rootfs.img..."
+e2fsck -fvy ${T}/rootfs.img
+
+echo ">>> Generate the LiveOS image structure..."
+
+mkdir -pv ${T}/LiveOS
+ln -v ${T}/rootfs.img ${T}/LiveOS/
+#mksquashfs ${W}/LiveOS/ ${W}/squashfs.img -comp zstd -root-becomes LiveOS -keep-as-directory -all-root
+time mksquashfs ${T}/LiveOS/ ${T}/squashfs.img -root-becomes LiveOS -keep-as-directory -all-root -b 1M -info -progress -comp lz4 #-Xhc
+rm -f ${T}/LiveOS/rootfs.img
+ln -v ${T}/squashfs.img ${T}/LiveOS/
+
+mkdir -pv ${T}/root
+mv -v ${T}/LiveOS ${T}/root/.
+
+echo ">>> Create and mount the efi.mg backing file..."
+fallocate -l 45M ${T}/efi.img
+mkfs.vfat -F 12 ${T}/efi.img -n EFIBOOTISO
+mount -vo loop ${T}/efi.img ${M}
+
+echo ">>> Set up EFI image..."
+mkdir -pv ${T}/mount/EFI/Boot
+cp -v ${B}/bootx64.efi ${M}/EFI/Boot/bootx64.efi
 sync
-mkdir -pv ${D}/mount/loader/entries
-cp -v ${D}/live-os.conf ${D}/mount/loader/entries/.
-cp -v ${D}/boot/kernel ${D}/mount/kernel
-cp -v ${D}/boot/initrd ${D}/mount/initrd
-umount ${D}/mount
+mkdir -pv ${T}/mount/loader/entries
+cp -v ${W}/live-os.conf ${M}/loader/entries/.
+cp -v ${B}/kernel ${M}/kernel
+cp -v ${B}/initrd ${M}/initrd
+umount -Rlv ${M}
 
-# Put it in place
-mkdir -pv ${D}/root/EFI/Boot
-mv -v ${D}/efi.img ${D}/root/EFI/Boot/efiboot.img
+echo ">>> Put the new EFI image in the correct place..."
+mkdir -pv ${T}/root/EFI/Boot
+mv -v ${T}/efi.img ${T}/root/EFI/Boot/efiboot.img
 
-# Create the ISO
+echo ">>> Create the ISO file..."
 xorriso -as mkisofs \
-    -o ${D}/snekvalidator.iso \
+    -o ${W}/snekvalidator.iso \
     -R -J -v -d -N \
     -x snekvalidator.iso \
     -hide-rr-moved \
@@ -213,7 +240,13 @@ xorriso -as mkisofs \
     -eltorito-boot EFI/Boot/efiboot.img \
     -isohybrid-gpt-basdat \
     -V "SERPENTISO" -A "SERPENTISO" \
-    root
+    ${T}/root
+
+cleanup
 
 unset RUST_BACKTRACE=1
-unset D
+unset B
+unset F
+unset M
+unset T
+unset W

--- a/desktop/img.sh
+++ b/desktop/img.sh
@@ -185,8 +185,8 @@ e2fsck -fvy ${TMPFS}/rootfs.img
 echo ">>> Generate the LiveOS image structure..."
 mkdir -pv ${TMPFS}/LiveOS
 ln -v ${TMPFS}/rootfs.img ${TMPFS}/LiveOS/
-#time mksquashfs ${WORK}/LiveOS/ ${WORK}/squashfs.img -root-becomes LiveOS -keep-as-directory -all-root -b 1M -info -progress -comp zstd
-time mksquashfs ${TMPFS}/LiveOS/ ${TMPFS}/squashfs.img -root-becomes LiveOS -keep-as-directory -all-root -b 1M -info -progress -comp lz4 #-Xhc
+#time mksquashfs ${WORK}/LiveOS/ ${WORK}/squashfs.img -root-becomes LiveOS -keep-as-directory -all-root -b 1M -info -progress -comp zstd #-Xcompression-level 3 # default is 15
+time mksquashfs ${TMPFS}/LiveOS/ ${TMPFS}/squashfs.img -root-becomes LiveOS -keep-as-directory -all-root -b 1M -info -progress -comp lz4 #-Xhc # yields 10% extra compression
 rm -f ${TMPFS}/LiveOS/rootfs.img
 ln -v ${TMPFS}/squashfs.img ${TMPFS}/LiveOS/
 


### PR DESCRIPTION
Speed up ISO generation a bit (tmpfs)

Lz4 was chosen for compression because it's insanely fast to create the squashfs (3s on my system) and because it gets easier to spot size improvements when the compression ratio is as low as it is w/lz4. For releases, switching to zstd should make it trivial to reduce time significantly with little perceived loss in decompression speed.

This approach avoids the OverlayFS terminal slowness, so should make image blitting a fair bit faster than before when creating ISOs.

Previous build times were around 8m for me. Current time is about 1m30s.

The tmpfs approach requires 8GiB free RAM to work.

Probably needs a bit of cleanup and I haven't tested if the damn thing actually _boots_.

Can probably get down to 1 minute if we make moss transaction rollback a reality.