### PR TITLE
desktop: Add various console troubleshooting utils

### DIFF
--- a/desktop/pkglist
+++ b/desktop/pkglist
@@ -21,4 +21,9 @@ linux-firmware-iwlwifi
 linux-firmware-nvidia
 lvm2
 
+dmidecode
+iproute2
+pciutils
+usbutils
+
 lichen


### PR DESCRIPTION
The idea is to make it easier to gain insight into hardware support and network configuration from within the live ISO.

Depends on https://github.com/serpent-os/recipes/pull/247