### PR TITLE
show-versions.bash: Change mangowc to mangowm

### DIFF
--- a/desktop/show-versions.bash
+++ b/desktop/show-versions.bash
@@ -20,7 +20,7 @@ desktops=(
 )
 wl_compositors=(
     '\nWayland_compositors:\n'
-    mangowc
+    mangowm
     niri
     sway
     weston


### PR DESCRIPTION
Mango has changed its name from mangowc to mangowm